### PR TITLE
Version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+
+- Fixed unhandled promise rejections causing noise in error tracking tools (e.g. Sentry)
+- `showUpdatePopup` and `startFlexibleUpdateWithProgress` now resolve with `"UPDATE_NOT_AVAILABLE"` when no update exists, and `"UPDATE_CHECK_FAILED"` when Play Core cannot reach the Play Store
+- `getUpdateInfo` now resolves with `null` on failure instead of rejecting
+
 ## 1.2.0
 
 - Added funtion to get update details

--- a/android/src/main/java/com/rninappupdate/RnInAppUpdateModule.kt
+++ b/android/src/main/java/com/rninappupdate/RnInAppUpdateModule.kt
@@ -52,12 +52,12 @@ class RnInAppUpdateModule(reactContext: ReactApplicationContext) :
           promise.reject("INTENT_ERROR", "Error starting update flow", e)
         }
       } else {
-        promise.reject("UPDATE_NOT_AVAILABLE", "Update not available or type not allowed")
+        promise.resolve("UPDATE_NOT_AVAILABLE")
       }
     }
 
-    appUpdateInfoTask.addOnFailureListener { e ->
-      promise.reject("UPDATE_ERROR", "Failed to get update info", e)
+    appUpdateInfoTask.addOnFailureListener { _ ->
+      promise.resolve("UPDATE_CHECK_FAILED")
     }
   }
 
@@ -77,8 +77,8 @@ class RnInAppUpdateModule(reactContext: ReactApplicationContext) :
         map.putString("packageName", info.packageName())
         promise.resolve(map)
       }
-      .addOnFailureListener { e ->
-        promise.reject("UPDATE_INFO_FAILED", "Failed to retrieve update info", e)
+      .addOnFailureListener { _ ->
+        promise.resolve(null)
       }
   }
 
@@ -125,12 +125,12 @@ class RnInAppUpdateModule(reactContext: ReactApplicationContext) :
           promise.reject("INTENT_ERROR", "Error starting update flow", e)
         }
       } else {
-        promise.reject("UPDATE_NOT_AVAILABLE", "No flexible update available")
+        promise.resolve("UPDATE_NOT_AVAILABLE")
       }
     }
 
-    appUpdateInfoTask.addOnFailureListener { e ->
-      promise.reject("UPDATE_ERROR", "Failed to get update info", e)
+    appUpdateInfoTask.addOnFailureListener { _ ->
+      promise.resolve("UPDATE_CHECK_FAILED")
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-rn-in-app-update",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A minimal React Native module that displays the native Android in-app update popup using the Play Core library. Supports both immediate and flexible update types.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
- Fixed unhandled promise rejections causing noise in error tracking tools (e.g. Sentry)
- `showUpdatePopup` and `startFlexibleUpdateWithProgress` now resolve with `"UPDATE_NOT_AVAILABLE"` when no update exists, and `"UPDATE_CHECK_FAILED"` when Play Core cannot reach the Play Store