### PR TITLE
ci: update npm publish token secret name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v2
         with:
           access: public
-          token: ${{secrets.NPM_TOKEN}}
+          token: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
Update the secret name used for npm publishing from `NPM_TOKEN` to `NPM_AUTH_TOKEN` in the GitHub Actions workflow.